### PR TITLE
Upgrade Flask version to 2.2.5

### DIFF
--- a/Core DW Infrastructure/dremio-api/requirements.txt
+++ b/Core DW Infrastructure/dremio-api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.4
+flask==2.2.5
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 requests


### PR DESCRIPTION
Upgraded Flask to a fixed version to address the missing Vary: Cookie header issue identified by Trivy