### PR TITLE
Upgrade Jinja2 from 2.11.3 to 3.1.5

### DIFF
--- a/Core DW Infrastructure/dremio-api/requirements.txt
+++ b/Core DW Infrastructure/dremio-api/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.4
-Jinja2==2.11.3
+Jinja2==3.1.5
 MarkupSafe==1.1.1
 requests
 pandas

--- a/Core DW Infrastructure/dremio-api/requirements.txt
+++ b/Core DW Infrastructure/dremio-api/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.4
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 requests
 pandas


### PR DESCRIPTION
Updated Core DW Infrastructure/dremio-api requirements to a fixed Jinja2 version flagged by Trivy code scanning (sandbox breakout via format method)