### PR TITLE
Update pillow version to 11.3.0

### DIFF
--- a/Asset-Assessment-Scanner-V1/requirements.txt
+++ b/Asset-Assessment-Scanner-V1/requirements.txt
@@ -7,7 +7,7 @@ numpy==2.0.2
 opencv-python==4.12.0.88
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 pytesseract==0.3.13
 python-dateutil==2.9.0.post0
 python-docx==1.1.2


### PR DESCRIPTION
Trivy code scanning flagged Pillow DDS heap buffer overflow in Asset-Assessment-Scanner-V1/requirements.txt. Upgrading pillow to fixed version 11.3.0.