### PR TITLE
Update fonttools version to 4.60.2

### DIFF
--- a/Asset-Assessment-Scanner-V1/requirements.txt
+++ b/Asset-Assessment-Scanner-V1/requirements.txt
@@ -1,6 +1,6 @@
 defusedxml==0.7.1
 Faker==37.1.0
-fonttools==4.57.0
+fonttools==4.60.2
 fpdf2==2.8.3
 lxml==5.4.0
 numpy==2.0.2


### PR DESCRIPTION
Trivy detected CVE-2025-66034 in fonttools 4.57.0, which allows arbitrary file write via malicious .designspace files. Updated fonttools to fixed version 4.60.2 in Asset-Assessment-Scanner-V1/requirements.txt.