### PR TITLE
Update requests library version to 2.32.4

### DIFF
--- a/Core DW Infrastructure/app/requirements.txt
+++ b/Core DW Infrastructure/app/requirements.txt
@@ -2,7 +2,7 @@ streamlit==1.48.0
 minio==7.1.11
 python-dotenv==1.0.0
 pyspark==3.5.0
-requests==2.31.0
+requests==2.32.4
 psycopg2-binary==2.9.6
 elasticsearch==7.17.9
 pandas==2.0.3


### PR DESCRIPTION
Trivy flagged CVE-2024-47081 in requests 2.31.0 (netrc credentials leak via malicious URLs). Updated requests to fixed version 2.32.4 in Core DW Infrastructure/app/requirements.txt.